### PR TITLE
Add alt text to the triangle image in the province dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this product will be documented in this file.
 
+## 2020-07-15
+
+### Bugfix
+* Added alt text to the triangle image on the province/territory dropdown
+
 ## 2020-07-09
 
 ### Bugfix

--- a/routes/question-province/js/question-province.js
+++ b/routes/question-province/js/question-province.js
@@ -6,4 +6,14 @@ accessibleAutocomplete.enhanceSelectElement({
   selectElement: document.querySelector('#province-select'),
   showAllValues: true,
   showNoOptionsFound: false,
+  dropdownArrow: () => {
+    var altText = '';
+    if (document.documentElement.lang === 'en'){
+      altText = 'List of provinces/territories'
+    }
+    else {
+      altText = 'Liste des provinces et territoires'
+    }
+    return `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" class="autocomplete__dropdown-arrow-down" alt="${altText}" focusable="false"><g stroke="none" fill="none" fill-rule="evenodd"><polygon fill="#000000" points="0 0 22 0 11 17"></polygon></g></svg>`
+  },
 })


### PR DESCRIPTION
# Description

Adds alt text to the triangle image on the province/territory dropdown.