### PR TITLE
remove autocomplete from dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this product will be documented in this file.
 
+## 2020-08-25
+
+### Changed
+* Removed auto-complete from province dropdown 
+
+
 ## 2020-08-21
 
 ### Changed

--- a/cypress/integration/bugs.spec.js
+++ b/cypress/integration/bugs.spec.js
@@ -7,7 +7,7 @@ describe('Found Bugs', () => {
     it('Check some-income lost-a-job to no-income', () => {
       cy.visit('/')
       cy.get('[data-cy=start]').click()
-      cy.answerInput('#province-select',"Ontario")
+      cy.answerSelect('#province-select',"on")
       cy.answerRB('#lost_joblost-some-income')
       cy.answerRB('#some_incomeemployed-lost-a-job')
       cy.answerRB('#reduced_income1000_or_less')

--- a/cypress/integration/results.spec.js
+++ b/cypress/integration/results.spec.js
@@ -26,7 +26,7 @@ describe('Result Page Only tests', () => {
 
 function provinceLookup(key, locale){
   return {
-    'on': {'en': 'Ontario', 'fr': 'Ontario'},
+    'on': {'en': 'on', 'fr': 'on'},
   }[key][locale];
 }
 describe('Paths and Benefits', () => {
@@ -41,7 +41,7 @@ describe('Paths and Benefits', () => {
       })
 
       it('EI Sickness CERB, Mortgage, Student Loans, CCB', () => {
-        cy.answerInput('#province-select',provinceLookup('on',lang))
+        cy.answerSelect('#province-select',provinceLookup('on',lang))
         cy.answerRB('#lost_joblost-all-income')
         cy.answerRB('#no_incomesick-or-quarantined')
         cy.answerRB('#mortgage_paymentsyes-mortgage')
@@ -59,7 +59,7 @@ describe('Paths and Benefits', () => {
       })
 
       it('CERB', () => {
-        cy.answerInput('#province-select',provinceLookup('on',lang))
+        cy.answerSelect('#province-select',provinceLookup('on',lang))
         cy.answerRB('#lost_joblost-all-income')
         cy.answerRB('#no_incomeself-employed-closed')
         cy.answerRB('#mortgage_paymentsno')
@@ -74,7 +74,7 @@ describe('Paths and Benefits', () => {
       })
 
       it('EI Regular Cerb', () => {
-        cy.answerInput('#province-select',provinceLookup('on',lang))
+        cy.answerSelect('#province-select',provinceLookup('on',lang))
         cy.answerRB('#lost_joblost-some-income')
         cy.answerRB('#some_incomehours-reduced')
         cy.answerRB('#reduced_income1000_or_less')
@@ -90,7 +90,7 @@ describe('Paths and Benefits', () => {
       })
 
       it('RRIF', () => {
-        cy.answerInput('#province-select',provinceLookup('on',lang))
+        cy.answerSelect('#province-select',provinceLookup('on',lang))
         cy.answerRB('#lost_joblost-some-income')
         cy.answerRB('#some_incomeretired')
         cy.answerRB('#gross_income4999_or_less')
@@ -107,7 +107,7 @@ describe('Paths and Benefits', () => {
       })
 
       it('OAS', () => {
-        cy.answerInput('#province-select',provinceLookup('on',lang))
+        cy.answerSelect('#province-select',provinceLookup('on',lang))
         cy.answerRB('#lost_joblost-some-income')
         cy.answerRB('#some_incomeretired')
         cy.answerRB('#gross_income4999_or_less')
@@ -124,7 +124,7 @@ describe('Paths and Benefits', () => {
       })
 
       it('Rent Help, Student Financial Aid', () => {
-        cy.answerInput('#province-select',provinceLookup('on',lang))
+        cy.answerSelect('#province-select',provinceLookup('on',lang))
         cy.answerRB('#lost_joblost-no-income')
         cy.answerRB('#unchanged_incomestudent_2019_20')
         cy.answerRB('#mortgage_paymentsyes-rent')
@@ -141,7 +141,7 @@ describe('Paths and Benefits', () => {
       })
 
       it('dtc-alone', () => {
-        cy.answerInput('#province-select',provinceLookup('on',lang))
+        cy.answerSelect('#province-select',provinceLookup('on',lang))
         cy.answerRB('#lost_joblost-no-income')
         cy.answerRB('#unchanged_incomenone-of-the-above')
         cy.answerRB('#mortgage_paymentsno')
@@ -156,7 +156,7 @@ describe('Paths and Benefits', () => {
       })
 
       it('dtc-child', () => {
-        cy.answerInput('#province-select',provinceLookup('on',lang))
+        cy.answerSelect('#province-select',provinceLookup('on',lang))
         cy.answerRB('#lost_joblost-no-income')
         cy.answerRB('#unchanged_incomenone-of-the-above')
         cy.answerRB('#mortgage_paymentsno')
@@ -171,7 +171,7 @@ describe('Paths and Benefits', () => {
       })
 
       it('dtc-apply-individual', () => {
-        cy.answerInput('#province-select',provinceLookup('on',lang))
+        cy.answerSelect('#province-select',provinceLookup('on',lang))
         cy.answerRB('#lost_joblost-no-income')
         cy.answerRB('#unchanged_incomenone-of-the-above')
         cy.answerRB('#mortgage_paymentsno')
@@ -186,7 +186,7 @@ describe('Paths and Benefits', () => {
       })
 
       it('dtc-apply-child', () => {
-        cy.answerInput('#province-select',provinceLookup('on',lang))
+        cy.answerSelect('#province-select',provinceLookup('on',lang))
         cy.answerRB('#lost_joblost-no-income')
         cy.answerRB('#unchanged_incomenone-of-the-above')
         cy.answerRB('#mortgage_paymentsno')
@@ -201,7 +201,7 @@ describe('Paths and Benefits', () => {
       })
 
       it('dtc-oas', () => {
-        cy.answerInput('#province-select',provinceLookup('on',lang))
+        cy.answerSelect('#province-select',provinceLookup('on',lang))
         cy.answerRB('#lost_joblost-no-income')
         cy.answerRB('#unchanged_incomenone-of-the-above')
         cy.answerRB('#mortgage_paymentsno')

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -37,3 +37,9 @@ Cypress.Commands.add("answerInput", (id, val) => {
   cy.get(id).type(val)
   cy.get('[data-cy=next]').click()
 })
+
+Cypress.Commands.add("answerSelect", (id, val) =>{
+  cy.reportA11y()
+  cy.get(id).select(val)
+  cy.get('[data-cy=next]').click()
+})

--- a/routes/question-province/js/question-province.js
+++ b/routes/question-province/js/question-province.js
@@ -1,6 +1,6 @@
 // your js code here
 
-import accessibleAutocomplete from 'accessible-autocomplete'
+/* import accessibleAutocomplete from 'accessible-autocomplete'
 
 accessibleAutocomplete.enhanceSelectElement({
   selectElement: document.querySelector('#province-select'),
@@ -16,4 +16,4 @@ accessibleAutocomplete.enhanceSelectElement({
     }
     return `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" class="autocomplete__dropdown-arrow-down" alt="${altText}" focusable="false"><g stroke="none" fill="none" fill-rule="evenodd"><polygon fill="#000000" points="0 0 22 0 11 17"></polygon></g></svg>`
   },
-})
+}) */


### PR DESCRIPTION
# Description

removed auto complete drop-down in favour of native browser drop-downs by commenting out initialization of accessible-autocomplete in the question-province route 

Perhaps a few screenshots would be in order?

Firefox
![Screen Shot 2020-08-25 at 11 51 15 AM](https://user-images.githubusercontent.com/26819992/91197430-4ba2d900-e6c9-11ea-9c34-dd53ad8e3c3f.png)


Chrome
![Screen Shot 2020-08-25 at 11 52 01 AM](https://user-images.githubusercontent.com/26819992/91197520-65dcb700-e6c9-11ea-8799-598f624da353.png)


## Test Instructions

1. run application locally and navigate to /en/province and /fr/province


## Checklist
- [ x] Update CHANGELOG.md
- [ N/A] Unit tests have been added/updated
- [x ] e2e tests have been added/updated