### PR TITLE
Travel options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 All notable changes to this product will be documented in this file.
 
-## 2020-01-12
+## 2021-01-26
+
+### Changed
+* Added a travel option to no income and some income situations. CRB and EI are not available when quarantining after travelling internationally
+
+## 2021-01-12
 
 ### Removed
 * DTC and OAS routes have been removed

--- a/cypress/integration/results.spec.js
+++ b/cypress/integration/results.spec.js
@@ -48,6 +48,16 @@ describe('Paths and Benefits', () => {
         cy.get('#transition_to_ei')
       })
 
+      it("CRB not available during quarantine from international travel", () => {
+        cy.answerSelect('#province-select', provinceLookup('on', lang))
+        cy.answerRB('#lost_joblost-all-income')
+        cy.answerRB('#no_incomeself-isolating-travel')
+        cy.answerRB('#mortgage_paymentsno')
+        cy.answerRB('#student_debtno')
+        cy.answerRB('#plans_for_schoolno')
+        cy.get('[data-cy=eligible-benefit-list]').should('not.exist')
+      })
+
       it("CRCB", () => {
         cy.answerSelect('#province-select', provinceLookup('on', lang))
         cy.answerRB('#lost_joblost-all-income')
@@ -88,6 +98,16 @@ describe('Paths and Benefits', () => {
         cy.get('#transition_to_ei')
       })
 
+      it('EI Regular not available during quarantine after international travel', () => {
+        cy.answerSelect('#province-select', provinceLookup('on', lang))
+        cy.answerRB('#lost_joblost-some-income')
+        cy.answerRB('#some_incomeself-isolating-travel')
+        cy.answerRB('#mortgage_paymentsno')
+        cy.answerRB('#student_debtno')
+        cy.answerRB('#plans_for_schoolno')
+        cy.reportA11y()
+        cy.get('[data-cy=eligible-benefit-list]').should('not.exist')
+      })
 
       it('RRIF', () => {
         cy.answerSelect('#province-select', provinceLookup('on', lang))

--- a/locales/en.json
+++ b/locales/en.json
@@ -217,6 +217,7 @@
   "your_situation.some_income.4": "You’re retired and lost your part-time work.",
   "your_situation.some_income.5": "You’re sick or in mandatory quarantine and on unpaid leave.",
   "your_situation.some_income.6": "Your child or dependent's school, daycare or care facility is closed due to COVID-19.",
+  "your_situation.some_income.7": "You're self-isolating or in quarantine due to international travel.",
   "your_situation.some_income.none": "None of the above.",
   "your_situation.unchanged_income.1": "You’re working from home.",
   "your_situation.unchanged_income.2": "You’re on paid leave.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -209,6 +209,7 @@
   "your_situation.no_income.7": "You were on parental leave recently, but you cannot return to work due to COVID-19.",
   "your_situation.no_income.8": "You were a post-secondary student during the 2019-20 school year and now cannot find work.",
   "your_situation.no_income.9": "You were on Employment Insurance Regular or Fishing Benefits and your claim ended on or after December&nbsp;29,&nbsp;2019.",
+  "your_situation.no_income.10": "You're self-isolating or in quarantine due to international travel.",
   "your_situation.no_income.none": "None of the above.",
   "your_situation.some_income.1": "Your employer has reduced your hours due to COVID-19.",
   "your_situation.some_income.2": "You’ve lost one or two part-time jobs and still have some income.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -215,6 +215,7 @@
   "your_situation.no_income.7": "Vous étiez récemment en congé parental, mais ne pouvez pas retourner travailler en raison de la COVID-19.",
   "your_situation.no_income.8": "Vous étiez étudiant dans une institution postsecondaire lors de l’année scolaire 2019-20 et ne pouvez pas trouver d’emploi.",
   "your_situation.no_income.9": "Vous receviez des prestations régulières d’assurance-emploi ou de pêcheur, et vos prestations ont cessé le 29&nbsp;décembre&nbsp2019 ou plus tard.",
+  "your_situation.no_income.10": "Vous êtes en isolement ou quarantaine en raison d’un voyage à l’étranger.",
   "your_situation.no_income.none": "Aucune de ces options.",
   "your_situation.some_income.1": "Votre employeur a réduit votre horaire de travail en raison de la COVID-19.",
   "your_situation.some_income.2": "Vous avez perdu un ou deux de vos emplois à temps partiel, mais avez toujours un revenu additionnel.",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -223,6 +223,7 @@
   "your_situation.some_income.4": "Vous êtes retraité et avez perdu un emploi à temps partiel.",
   "your_situation.some_income.5": "Vous êtes en congé sans solde alors que vous êtes malade ou en quarantaine obligatoire.",
   "your_situation.some_income.6": "L’école, le service de garde ou le centre de jour de votre enfant ou d’un enfant à votre charge est fermé en raison de la COVID-19.",
+  "your_situation.some_income.7": "Vous êtes en isolement ou quarantaine en raison d’un voyage à l’étranger.",
   "your_situation.some_income.none": "Aucune de ces options.",
   "your_situation.unchanged_income.1": "Vous faites du télétravail.",
   "your_situation.unchanged_income.2": "Vous êtes en congé payé.",

--- a/routes/question-your-situation-no-income/question-your-situation-no-income.controller.js
+++ b/routes/question-your-situation-no-income/question-your-situation-no-income.controller.js
@@ -19,13 +19,23 @@ module.exports = (app, route) => {
 }
 
 const postNoIncome = (req, res) => {
-  // prune the paths you can't go down on this route
-  pruneSessionData(req, [
+
+  const prunePaths = [
     'some_income',
     'unchanged_income',
     'reduced-income',
     'rrif',
     'gross_income',
-  ])
-  return res.redirect(res.locals.routePath('question-gross-income'))
+    'mortgage_payments',
+  ]
+
+  let path = res.locals.routePath('question-gross-income')
+
+  if (req.body.no_income === 'self-isolating-travel'){
+    path = res.locals.routePath('question-mortgage-payments')
+  }
+
+  // prune the paths you can't go down on this route
+  pruneSessionData(req, prunePaths)
+  return res.redirect(path)
 }

--- a/routes/question-your-situation-no-income/question-your-situation-no-income.njk
+++ b/routes/question-your-situation-no-income/question-your-situation-no-income.njk
@@ -14,6 +14,7 @@
                     { value: 'child-or-dependent-school-closed', text:__('your_situation.no_income.4')},
                     { value: 'unpaid-leave-to-care', text:__('your_situation.no_income.5')},
                     { value: 'sick-or-quarantined', text:__('your_situation.no_income.6')},
+                    { value: 'self-isolating-travel', text:__('your_situation.no_income.10')},
                     { value: 'parental-recently-cant-return', text:__('your_situation.no_income.7')},
                     { value: 'student_2019_20', text:__('your_situation.no_income.8')},
                     { value: 'ei-recently-claim-ended', text:__('your_situation.no_income.9')},

--- a/routes/question-your-situation-no-income/schema.js
+++ b/routes/question-your-situation-no-income/schema.js
@@ -8,7 +8,7 @@ const Schema = {
         'lost-job','employer-closed','self-employed-closed',
         'unpaid-leave-to-care',
         'sick-or-quarantined', 'parental-recently-cant-return',
-        'child-or-dependent-school-closed',
+        'child-or-dependent-school-closed', 'self-isolating-travel',
         'student_2019_20',
         'ei-recently-claim-ended',
         'none-of-the-above',

--- a/routes/question-your-situation-some-income/question-your-situation-some-income.controller.js
+++ b/routes/question-your-situation-some-income/question-your-situation-some-income.controller.js
@@ -19,7 +19,18 @@ module.exports = (app, route) => {
 }
 
 const postSomeIncome = (req, res) => {
-  pruneSessionData(req, ['no_income', 'unchanged_income'])
+
+  const prunePaths = [
+    'no_income',
+    'unchanged_income',
+    'gross_income',
+    'mortgage_payments',
+  ]
+
+  let path = res.locals.routePath('question-gross-income')
+
+  pruneSessionData(req, prunePaths)
+
   if (
     [
       'hours-reduced',
@@ -32,11 +43,13 @@ const postSomeIncome = (req, res) => {
     pruneSessionData(req, [ 'rrif'])
 
   }
-
   else if (req.body.some_income === 'retired') {
-    return res.redirect(res.locals.routePath('question-rrif'))
+    path = res.locals.routePath('question-rrif')
+  }
+  else if (req.body.some_income === 'self-isolating-travel') {
+    path = res.locals.routePath('question-mortgage-payments')
   }
 
-  return res.redirect(res.locals.routePath('question-gross-income'))
+  return res.redirect(path)
 
 }

--- a/routes/question-your-situation-some-income/question-your-situation-some-income.njk
+++ b/routes/question-your-situation-some-income/question-your-situation-some-income.njk
@@ -14,6 +14,7 @@
                     { value: 'selfemployed-some-income', text:__('your_situation.some_income.3')},
                     { value: 'retired', text:__('your_situation.some_income.4')},
                     { value: 'quarantine', text:__('your_situation.some_income.5')},
+                    { value: 'self-isolating-travel', text:__('your_situation.some_income.7')},
                     { value: 'child-or-dependent-school-closed', text: __('your_situation.some_income.6')},
                     { value: 'none-of-the-above', text:__('your_situation.some_income.none')}
                 ],

--- a/routes/question-your-situation-some-income/schema.js
+++ b/routes/question-your-situation-some-income/schema.js
@@ -11,6 +11,7 @@ const Schema = {
           'employed-lost-a-job',
           'retired',
           'quarantine',
+          'self-isolating-travel',
           'child-or-dependent-school-closed',
           'none-of-the-above',
         ],

--- a/routes/results/getBenefits.js
+++ b/routes/results/getBenefits.js
@@ -132,6 +132,18 @@ const getBenefits = (data, featureFlags) => {
       data,
       {
         lost_job: "lost-all-income",
+        no_income: [
+          'lost-job',
+          'employer-closed',
+          'self-employed-closed',
+          'child-or-dependent-school-closed',
+          'unpaid-leave-to-care',
+          'sick-or-quarantined',
+          'parental-recently-cant-return',
+          'student_2019_20',
+          'ei-recently-claim-ended',
+          'none-of-the-above',
+        ],
       },
       "transition_to_ei",
     ),

--- a/routes/results/getBenefits.js
+++ b/routes/results/getBenefits.js
@@ -154,6 +154,15 @@ const getBenefits = (data, featureFlags) => {
       data,
       {
         lost_job: "lost-some-income",
+        some_income: [
+          'hours-reduced',
+          'employed-lost-a-job',
+          'selfemployed-some-income',
+          'retired',
+          'quarantine',
+          'child-or-dependent-school-closed',
+          'none-of-the-above',
+        ],
       },
       "transition_to_ei",
     ),

--- a/routes/results/getBenefits.spec.js
+++ b/routes/results/getBenefits.spec.js
@@ -161,6 +161,17 @@ describe('Test the getBenefits calculator', () => {
     })
   })
 
+  test("lost all income + quarantine from international travel + don't show EI or CRB", () => {
+    const dataBody = {
+      lost_job: "lost-all-income",
+      no_income: "self-isolating-travel",
+    }
+
+    const result = getBenefits(dataBody)
+    expect(result).not.toContain("transition_to_ei")
+    expect(result).not.toContain("crb")
+  })
+
   test("lost some income + reduced income + 4999 or less shows ei + ei work sharing ", () => {
     const result = getBenefits(
       {
@@ -188,7 +199,7 @@ describe('Test the getBenefits calculator', () => {
     options.forEach((value) => {
       const dataBody = {
         lost_job: "lost-some-income",
-        no_income: value,
+        some_income: value,
         gross_income: "4999-or-less",
       }
 
@@ -213,6 +224,17 @@ describe('Test the getBenefits calculator', () => {
     expect(result).toContain("transition_to_ei")
     expect(result).toContain("ei_workshare")
     expect(result).toContain("crb")
+  })
+
+  test("lost some income + quarantine from international travel + don't show EI or CRB", () => {
+    const dataBody = {
+      lost_job: "lost-some-income",
+      some_income: "self-isolating-travel",
+    }
+
+    const result = getBenefits(dataBody)
+    expect(result).not.toContain("transition_to_ei")
+    expect(result).not.toContain("crb")
   })
 
   test('It checks the mortgage addon', () => {


### PR DESCRIPTION
# Description

Added an option to no income and some income situations for quarantining after international travel. EI and CRB are not available when these options are selected.

## Test Instructions

- On the lost income page, select all income has stopped or some income has stopped
- On the next page, select _You're self-isolating or in quarantine due to international travel._
- Notice the next question is about housing, rather than income earned
- Fill the rest of the questions however,
- Notice the results don't include CRB or EI

## Checklist
- [x] Update CHANGELOG.md
- [x] Unit tests have been added/updated
- [x] e2e tests have been added/updated